### PR TITLE
Fix Customer Worker type error

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -339,12 +339,37 @@ func (r *slaveRunner) onHatchMessage(msg *message) {
 		users, _ = msg.Data["num_clients"]
 	}
 	hatchRate := rate.(float64)
+
 	workers := 0
-	if _, ok := users.(uint64); ok {
-		workers = int(users.(uint64))
-	} else {
-		workers = int(users.(int64))
+	switch w := users.(type) {
+	case int:
+		workers = w
+	case int8:
+		workers = int(w)
+	case int16:
+		workers = int(w)
+	case int32:
+		workers = int(w)
+	case int64:
+		workers = int(w)
+	case uint:
+		workers = int(w)
+	case uint8:
+		workers = int(w)
+	case uint16:
+		workers = int(w)
+	case uint32:
+		workers = int(w)
+	case uint64:
+		workers = int(w)
+	case uintptr:
+		workers = int(w)
+	case float32:
+		workers = int(w)
+	case float64:
+		workers = int(w)
 	}
+
 	if workers == 0 || hatchRate == 0 {
 		log.Printf("Invalid hatch message from master, users is %d, hatch_rate is %.2f\n",
 			workers, hatchRate)


### PR DESCRIPTION
A Customer is reporting an issue where an exception is being thrown when
trying to hatch workers. This is due to the worker count being a
float64, instead of the expected int64.

As we've not been able to replicate the issue with the versions of
ably-boomer and Locust available to us, a decision has been to try and
handle every number type.

## Reported Stack Trace
> panic: interface conversion: interface {} is float64, not int64
goroutine 25 [running]:
github.com/ably-forks/boomer.(*slaveRunner).onHatchMessage(0xc0001640c0, 0xc00016aa50)
        /go/pkg/mod/github.com/ably-forks/boomer@v0.0.0-20200710093415-bd9a519eed27/runner.go:346 +0x4af
github.com/ably-forks/boomer.(*slaveRunner).onMessage(0xc0001640c0, 0xc00016aa50)
        /go/pkg/mod/github.com/ably-forks/boomer@v0.0.0-20200710093415-bd9a519eed27/runner.go:368 +0xec
github.com/ably-forks/boomer.(*slaveRunner).startListener.func1(0xc0001640c0)
        /go/pkg/mod/github.com/ably-forks/boomer@v0.0.0-20200710093415-bd9a519eed27/runner.go:410 +0x4c
created by github.com/ably-forks/boomer.(*slaveRunner).startListener
        /go/pkg/mod/github.com/ably-forks/boomer@v0.0.0-20200710093415-bd9a519eed27/runner.go:406 +0x3f